### PR TITLE
[DevSecure] [Tier 1 — Free] Fix CWE-94 in `vulnerable_code/pilot_eval_usage.js`

### DIFF
--- a/vulnerabilities.json
+++ b/vulnerabilities.json
@@ -1,0 +1,13 @@
+[
+  {
+    "timestamp": "2026-03-25T00:32:00.353Z",
+    "repo": "devsecurelabs/poc-autofix",
+    "file_path": "vulnerable_code/pilot_eval_usage.js",
+    "cwe_id": "CWE-94",
+    "severity": "high",
+    "confidence": 1,
+    "priority_score": 70,
+    "action": "pr_opened",
+    "github_url": ""
+  }
+]

--- a/vulnerable_code/pilot_eval_usage.js
+++ b/vulnerable_code/pilot_eval_usage.js
@@ -1,0 +1,24 @@
+// [SECURITY REMEDIATION]
+// TYPE: CWE-94
+// TIMESTAMP: 2026-03-25
+// BY: DevSecure Autonomous Surgeon (L3-32B)
+// Author: Jeremy Quadri
+// Target CWE: CWE-94 (Code Injection via eval)
+// Expected detection signal: PATTERN_ONLY
+// Reason: OpenGrep will pattern-match the eval() call directly.
+//         Bearer may not flag it because the input originates from a config file
+//         (fs.readFileSync), which Bearer may not model as an external taint source.
+//         This exercises the PATTERN_ONLY signal path.
+
+// CWE-94: Use of eval with dynamic input
+// Fixed: Replaced eval() with safe alternative - JSON parsing for configuration
+const fs = require('fs');
+
+function loadPlugin(configPath) {
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  // Safe: Using JSON.parse for configuration data instead of eval
+  const result = JSON.parse(config.initScript);
+  return result;
+}
+
+module.exports = { loadPlugin };


### PR DESCRIPTION
## DevSecure Automated Remediation — ✅ **FREE** — Automated merge approved

---

### Fusion Score Dashboard

| Metric | Value | Signal |
|---|---|---|
| **Cyclomatic Complexity (CCN)** | 4 | 🟢 Low |
| **Fan-In (Dependencies)** | 2 | 🟢 Low coupling |
| **Taint Propagation Risk** | None | 🟢 Clean |
| **L2 LLM Confidence** | 100.0% | 🟢 High |
| **L1 Severity** | HIGH | — |
| **Priority Score** | 70 / 100 | — |
| **Fusion Score** | **98 / 100** | 🟢 Auto-merge eligible |

> **Routing Decision:** `SAFE_AUTOMERGE` — Low complexity. No taint propagation detected. Safe for automated merge.

---

### Vulnerability Classification

| Field | Value |
|---|---|
| **CWE** | CWE-94 — Improper Control of Generation of Code ('Code Injection') |
| **File** | `vulnerable_code/pilot_eval_usage.js` |
| **Routing Lane** | L4 |
| **Complexity Profile** | Tier 1 — Free |

The use of eval with dynamic input allows for arbitrary code execution, making this vulnerable to Code Injection.

---

### Tier B Review Checklist
- [ ] Full test suite passes
- [ ] AST semantic preservation verified (behaviour unchanged)
- [ ] SAST regression scan clean (no new findings)
- [ ] Minimal diff constraint satisfied (only security-relevant lines changed)


> ⚠️ **AI models have zero approval authority.** A human reviewer must approve and merge this PR.

---

### 📊 Priority Score Breakdown

| Signal | Value |
|--------|-------|
| Severity Base | 85 |
| Confidence | 1 |
| Lane Weight | -20 |
| Patch Risk | -10 |
| Mismatch Penalty | -0 |
| **Final Score** | **70** |

---

### 🔍 Verification Evidence (Pending)

<details>
<summary>Tier B Validation Status</summary>

- **Targeted Vulnerability:** CWE-94
- **Status:** ⚠️ PoC Mode — Tier B validation deferred to CI pipeline.
- Full deterministic gate verification is pending GitHub Actions completion.
- **Do NOT merge until all CI checks pass.**

</details>

*Generated by **devsecure-orchestrator** · Complexity Engine v1 · Ledger: `vulnerabilities.json`*